### PR TITLE
Test ddtest GitHub Actions matrix output docs

### DIFF
--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -32,7 +32,7 @@ jobs:
       DD_SERVICE: forem-circleci
       DD_TEST_OPTIMIZATION_RUNNER_MAX_PARALLELISM: 8
       DD_TEST_OPTIMIZATION_RUNNER_CI_NODE_WORKERS: 1
-      DD_TEST_OPTIMIZATION_RUNNER_WORKER_ENV: DATABASE_URL_TEST=postgres://postgres:postgres@localhost:5432/Forem_test{{nodeIndex}}
+      DD_TEST_OPTIMIZATION_RUNNER_WORKER_ENV: DATABASE_URL_TEST=postgres://postgres:postgres@localhost:5432/Forem_test{{nodeIndex}};DATABASE_NAME_TEST=Forem_test{{nodeIndex}}
     steps:
       - checkout
       - restore_cache:
@@ -47,11 +47,11 @@ jobs:
       - run:
           name: Prepare test database for this CI node
           command: |
-            # CI_NODE_WORKERS=1, so ddtest runs single-worker mode and {{nodeIndex}}
-            # expands to ciNode*10000.
             NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
-            GLOBAL=$((NODE_INDEX * 10000))
-            DATABASE_URL_TEST="postgres://postgres:postgres@localhost:5432/Forem_test${GLOBAL}" bundle exec rails db:test:prepare
+            DATABASE_NAME="Forem_test${NODE_INDEX}"
+            DATABASE_URL_TEST="postgres://postgres:postgres@localhost:5432/${DATABASE_NAME}" \
+              DATABASE_NAME_TEST="${DATABASE_NAME}" \
+              bundle exec rails db:test:prepare
       - test-optimization-circleci-orb/autoinstrument:
           languages: ruby
           site: datadoghq.eu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
+      matrix: ${{ steps.dd_plan.outputs.matrix }}
     env:
       E2E: true
 
@@ -70,11 +70,9 @@ jobs:
           chmod +x bin/ddtest
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: Setup Datadog Test Runner
+      - id: dd_plan
+        name: Setup Datadog Test Runner
         run: bin/ddtest plan
-      - name: Set matrix output
-        id: matrix
-        run: cat .testoptimization/github/config >> $GITHUB_OUTPUT
       - name: Upload DD artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -88,7 +86,6 @@ jobs:
     needs: [build]
     timeout-minutes: 20
     env:
-      DD_TEST_OPTIMIZATION_RUNNER_CI_NODE: ${{ matrix.ci_node_index }}
       DD_TEST_OPTIMIZATION_RUNNER_WORKER_ENV: DATABASE_URL_TEST=postgres://postgres:postgres@localhost:5432/Forem_test{{nodeIndex}}
 
     services:
@@ -133,7 +130,7 @@ jobs:
       - run: cp .env_sample .env
       - name: Prepare test database for this CI node
         run: |
-          DATABASE_URL_TEST="postgres://postgres:postgres@localhost:5432/Forem_test${DD_TEST_OPTIMIZATION_RUNNER_CI_NODE}" bundle exec rails db:test:prepare
+          DATABASE_URL_TEST="postgres://postgres:postgres@localhost:5432/Forem_test${{ matrix.ci_node_index }}" bundle exec rails db:test:prepare
       - name: Configure Datadog Test Optimization
         uses: datadog/test-visibility-github-action@v2
         with:
@@ -149,4 +146,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: RSpec
-        run: bin/ddtest run
+        run: bin/ddtest run --ci-node ${{ matrix.ci_node_index }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
           site: datadoghq.eu
       - name: Download ddtest binary
         run: |
-          mkdir -p bin
-          gh release download --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
+          LATEST_PRERELEASE_TAG=$(gh release list --repo DataDog/ddtest --json tagName,isPrerelease --jq '.[] | select(.isPrerelease) | .tagName' | head -n 1)
+          gh release download "$LATEST_PRERELEASE_TAG" --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
           mv bin/ddtest-linux-amd64 bin/ddtest
           chmod +x bin/ddtest
         env:
@@ -139,8 +139,8 @@ jobs:
           site: datadoghq.eu
       - name: Download ddtest binary
         run: |
-          mkdir -p bin
-          gh release download --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
+          LATEST_PRERELEASE_TAG=$(gh release list --repo DataDog/ddtest --json tagName,isPrerelease --jq '.[] | select(.isPrerelease) | .tagName' | head -n 1)
+          gh release download "$LATEST_PRERELEASE_TAG" --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
           mv bin/ddtest-linux-amd64 bin/ddtest
           chmod +x bin/ddtest
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
           site: datadoghq.eu
       - name: Download ddtest binary
         run: |
-          LATEST_PRERELEASE_TAG=$(gh release list --repo DataDog/ddtest --json tagName,isPrerelease --jq '.[] | select(.isPrerelease) | .tagName' | head -n 1)
-          gh release download "$LATEST_PRERELEASE_TAG" --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
+          mkdir -p bin
+          gh release download --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
           mv bin/ddtest-linux-amd64 bin/ddtest
           chmod +x bin/ddtest
         env:
@@ -139,8 +139,8 @@ jobs:
           site: datadoghq.eu
       - name: Download ddtest binary
         run: |
-          LATEST_PRERELEASE_TAG=$(gh release list --repo DataDog/ddtest --json tagName,isPrerelease --jq '.[] | select(.isPrerelease) | .tagName' | head -n 1)
-          gh release download "$LATEST_PRERELEASE_TAG" --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
+          mkdir -p bin
+          gh release download --repo DataDog/ddtest --pattern "ddtest-linux-amd64" --dir bin
           mv bin/ddtest-linux-amd64 bin/ddtest
           chmod +x bin/ddtest
         env:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -137,7 +137,8 @@ class User < ApplicationRecord
   validates :following_orgs_count, presence: true
   validates :following_tags_count, presence: true
   validates :following_users_count, presence: true
-  validates :name, length: { in: 1..100 }, presence: true
+  validates :name,
+            length: { in: 1..100 }, presence: true
   validates :password, length: { in: 8..100 }, allow_nil: true
   validates :rating_votes_count, presence: true
   validates :reactions_count, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,7 +90,7 @@ class User < ApplicationRecord
                                         inverse_of: :offender, foreign_key: :offender_id, dependent: :nullify
   has_many :organization_memberships, dependent: :delete_all
   has_many :organizations, through: :organization_memberships
-  # Page views stay with the article, not the user who viewed it.
+  # Page views remain with the article, not the user who viewed it.
   has_many :page_views, dependent: :nullify
   has_many :podcast_episode_appearances, dependent: :delete_all, inverse_of: :user
   has_many :podcast_episodes, through: :podcast_episode_appearances, source: :podcast_episode

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,7 +90,7 @@ class User < ApplicationRecord
                                         inverse_of: :offender, foreign_key: :offender_id, dependent: :nullify
   has_many :organization_memberships, dependent: :delete_all
   has_many :organizations, through: :organization_memberships
-  # we keep page views as they belong to the article, not to the user who viewed it
+  # Page views stay with the article, not the user who viewed it.
   has_many :page_views, dependent: :nullify
   has_many :podcast_episode_appearances, dependent: :delete_all, inverse_of: :user
   has_many :podcast_episodes, through: :podcast_episode_appearances, source: :podcast_episode


### PR DESCRIPTION
## Summary

- Update the Forem GitHub Actions workflow to use the new ddtest step output directly from `ddtest plan`.
- Remove the manual `.testoptimization/github/config` to `$GITHUB_OUTPUT` bridge.
- Keep the prerelease ddtest download path while validating the unreleased output behavior.
- Fix the CircleCI ddtest setup so each CircleCI node prepares the same suffixed test database that ddtest injects into workers.
- Add harmless `app/models/user.rb` touches to retrigger/compare CI behavior.

## Validation

- Confirmed a docs-only GitHub Actions run passed after the prerelease path was restored.
- Confirmed `ddtest plan` produced a 5-runner matrix in the later code-touch run.
- Confirmed the CircleCI config parses as YAML locally.
- Investigating the remaining `ApplicationHelper#release_adjusted_cache_key` RSpec failure as likely Forem/TIA state leakage rather than a ddtest runner failure.
