### PR TITLE
[codex] Adopt ddtest discovery cache and exclude pattern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,8 @@ jobs:
           name: Determine parallelism
           command: |
             set -euo pipefail
-            cat .testoptimization/parallel-runners.txt
-            desired=$(cat .testoptimization/parallel-runners.txt 2>/dev/null || echo 1)
+            cat .testoptimization/runner/parallel-runners.txt
+            desired=$(cat .testoptimization/runner/parallel-runners.txt 2>/dev/null || echo 1)
             if ! echo "${desired}" | grep -Eq '^[0-9]+$'; then
               echo "Invalid parallelism value '${desired}', defaulting to 1"
               desired=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ env:
   DD_TEST_OPTIMIZATION_RUNNER_FRAMEWORK: rspec
   DD_TEST_OPTIMIZATION_RUNNER_MIN_PARALLELISM: 1
   DD_TEST_OPTIMIZATION_RUNNER_MAX_PARALLELISM: 8
+  DD_TEST_OPTIMIZATION_RUNNER_TEST_DISCOVERY_CACHE: .ddtest-cache/tests-discovery.json
+  DD_TEST_OPTIMIZATION_RUNNER_TESTS_EXCLUDE_PATTERN: 'spec/ddtest/excluded/**/*_spec.rb'
+  DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED: 'false'
 
 jobs:
   build:
@@ -34,6 +37,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Restore DDTest discovery cache
+        uses: actions/cache@v4
+        with:
+          path: .ddtest-cache/tests-discovery.json
+          key: ddtest-discovery-${{ runner.os }}-${{ github.ref_name }}
+          restore-keys: |
+            ddtest-discovery-${{ runner.os }}-
+            ddtest-discovery-
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -73,6 +84,20 @@ jobs:
       - id: dd_plan
         name: Setup Datadog Test Runner
         run: bin/ddtest plan
+      - name: Verify DDTest exclude pattern
+        run: |
+          test -s .testoptimization/runner/test-files.txt
+          if grep -Fq "spec/ddtest/excluded/exclude_pattern_canary_spec.rb" .testoptimization/runner/test-files.txt .testoptimization/runner/tests-split/runner-*; then
+            echo "DDTest exclude pattern did not filter the canary spec" >&2
+            exit 1
+          fi
+      - name: Save latest DDTest discovery cache
+        if: always()
+        run: |
+          if [ -f .testoptimization/tests-discovery/tests.json ]; then
+            mkdir -p .ddtest-cache
+            cp .testoptimization/tests-discovery/tests.json .ddtest-cache/tests-discovery.json
+          fi
       - name: Upload DD artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -86,7 +111,7 @@ jobs:
     needs: [build]
     timeout-minutes: 20
     env:
-      DD_TEST_OPTIMIZATION_RUNNER_WORKER_ENV: DATABASE_URL_TEST=postgres://postgres:postgres@localhost:5432/Forem_test{{nodeIndex}}
+      DD_TEST_OPTIMIZATION_RUNNER_WORKER_ENV: DATABASE_URL_TEST=postgres://postgres:postgres@localhost:5432/Forem_test{{nodeIndex}};DATABASE_NAME_TEST=Forem_test{{nodeIndex}}
 
     services:
       postgres:
@@ -130,7 +155,10 @@ jobs:
       - run: cp .env_sample .env
       - name: Prepare test database for this CI node
         run: |
-          DATABASE_URL_TEST="postgres://postgres:postgres@localhost:5432/Forem_test${{ matrix.ci_node_index }}" bundle exec rails db:test:prepare
+          DATABASE_NAME="Forem_test${{ matrix.ci_node_index }}"
+          DATABASE_URL_TEST="postgres://postgres:postgres@localhost:5432/${DATABASE_NAME}" \
+            DATABASE_NAME_TEST="${DATABASE_NAME}" \
+            bundle exec rails db:test:prepare
       - name: Configure Datadog Test Optimization
         uses: datadog/test-visibility-github-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # DDTest discovery cache validation needs the cache source commit locally.
           fetch-depth: 3
       - name: Restore DDTest discovery cache
         id: ddtest_discovery_cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,13 @@ jobs:
         with:
           fetch-depth: 3
       - name: Restore DDTest discovery cache
-        uses: actions/cache@v4
+        id: ddtest_discovery_cache
+        uses: actions/cache/restore@v4
         with:
           path: .ddtest-cache/tests-discovery.json
-          key: ddtest-discovery-${{ runner.os }}-${{ github.ref_name }}
+          key: ddtest-discovery-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
+            ddtest-discovery-${{ runner.os }}-${{ github.ref_name }}-
             ddtest-discovery-${{ runner.os }}-
             ddtest-discovery-
       - name: Setup Ruby
@@ -93,13 +95,23 @@ jobs:
             echo "DDTest exclude pattern did not filter the canary spec" >&2
             exit 1
           fi
-      - name: Save latest DDTest discovery cache
+      - id: stage_ddtest_discovery_cache
+        name: Stage latest DDTest discovery cache
         if: always()
         run: |
           if [ -f .testoptimization/tests-discovery/tests.json ]; then
             mkdir -p .ddtest-cache
             cp .testoptimization/tests-discovery/tests.json .ddtest-cache/tests-discovery.json
+            echo "cache-ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "cache-ready=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Save latest DDTest discovery cache
+        if: always() && steps.stage_ddtest_discovery_cache.outputs.cache-ready == 'true' && steps.ddtest_discovery_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .ddtest-cache/tests-discovery.json
+          key: ${{ steps.ddtest_discovery_cache.outputs.cache-primary-key }}
       - name: Upload DD artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Restore DDTest discovery cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Restore DDTest discovery cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 3
       - name: Restore DDTest discovery cache
         uses: actions/cache@v4
         with:

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -13,7 +13,7 @@ class Article < ApplicationRecord
   resourcify
 
   include StringAttributeCleaner.nullify_blanks_for(:canonical_url, on: :before_save)
-  DEFAULT_FEED_PAGINATION_WINDOW_SIZE = 50
+  DEFAULT_FEED_PAGINATION_WINDOW_SIZE = 5 * 10
 
   # When we cache an entity, either {User} or {Organization}, these are the names of the attributes
   # we cache.

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -13,7 +13,7 @@ class Article < ApplicationRecord
   resourcify
 
   include StringAttributeCleaner.nullify_blanks_for(:canonical_url, on: :before_save)
-  DEFAULT_FEED_PAGINATION_WINDOW_SIZE = 5 * 10
+  DEFAULT_FEED_PAGINATION_WINDOW_SIZE = 50
 
   # When we cache an entity, either {User} or {Organization}, these are the names of the attributes
   # we cache.

--- a/app/services/user_subscriptions/create_from_controller_params.rb
+++ b/app/services/user_subscriptions/create_from_controller_params.rb
@@ -14,7 +14,7 @@ module UserSubscriptions
       @user = user
       @source_type = user_subscription_params[:source_type]
       @source_id = user_subscription_params[:source_id]
-      @response = Response.new(success: false)
+      @response = Response.new(success: false, data: nil, error: nil)
 
       # TODO: [@forem/delightful]: uncomment this once email confirmation is re-enabled
       # @subscriber_email = user_subscription_params[:subscriber_email]

--- a/spec/ddtest/excluded/exclude_pattern_canary_spec.rb
+++ b/spec/ddtest/excluded/exclude_pattern_canary_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Touch this spec-tree file when validating DDTest discovery-cache invalidation.
+# The file stays excluded from ddtest execution but still belongs to the spec root.
 RSpec.describe "DDTest exclude pattern canary" do
   it "would be discovered without the ddtest exclude pattern" do
     expect(true).to be(true)

--- a/spec/ddtest/excluded/exclude_pattern_canary_spec.rb
+++ b/spec/ddtest/excluded/exclude_pattern_canary_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe "DDTest exclude pattern canary" do
+  it "would be discovered without the ddtest exclude pattern" do
+    expect(true).to be(true)
+  end
+end

--- a/spec/ddtest/excluded/exclude_pattern_canary_spec.rb
+++ b/spec/ddtest/excluded/exclude_pattern_canary_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Touch this spec-tree file when validating DDTest discovery-cache invalidation.
 RSpec.describe "DDTest exclude pattern canary" do
   it "would be discovered without the ddtest exclude pattern" do
     expect(true).to be(true)

--- a/spec/services/open_graph_spec.rb
+++ b/spec/services/open_graph_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 describe OpenGraph, :vcr, type: :service do
+  # Exercises ddtest discovery-cache invalidation for changed specs.
   VCR.use_cassette("open_graph") do
     let(:page) { described_class.new("https://github.com/forem") }
   end


### PR DESCRIPTION
## Summary

Adopt two newly released DDTest runner features in Forem's own GitHub Actions CI:

- restore and save DDTest's test discovery cache around `ddtest plan`
- configure `DD_TEST_OPTIMIZATION_RUNNER_TESTS_EXCLUDE_PATTERN` with a canary spec under `spec/ddtest/excluded/`
- verify the canary is excluded from the planned runner inputs before uploading DDTest artifacts

This also fixes two CI issues found while validating the branch:

- disable Datadog Early Flake Detection for this ddtest runner workflow so the suite is not multiplied by 10 EFD retries
- pass both `DATABASE_URL_TEST` and `DATABASE_NAME_TEST` through ddtest worker env, matching Forem's database config and CircleCI setup
- update CircleCI's setup workflow to read `.testoptimization/runner/parallel-runners.txt`, the ddtest 1.0 path

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".circleci/config.yml"); YAML.load_file(".circleci/test.yml")'`
- `git diff --check`
- `ruby -c spec/ddtest/excluded/exclude_pattern_canary_spec.rb`
- GitHub Actions run is green: https://github.com/anmarchenko/forem/actions/runs/27535502480
  - `build` passed, including discovery cache restore/save and exclude-pattern verification
  - all six RSpec shards passed under the original 20-minute timeout
  - old timed-out run had 3,622-6,530 `RSpec::Retry` lines per shard; final run has 0 per shard
  - final shard logs show ddtest worker env includes both `DATABASE_NAME_TEST` and `DATABASE_URL_TEST`
- CircleCI setup and continuation are green:
  - plan: https://circleci.com/gh/anmarchenko/forem/114
  - test: https://circleci.com/gh/anmarchenko/forem/115
