### PR TITLE
Dogfood ddtest runtime tags override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       matrix: ${{ steps.dd_plan.outputs.matrix }}
     env:
       E2E: true
+      DD_TEST_OPTIMIZATION_RUNNER_RUNTIME_TAGS: '{"os.version":"6.12.80"}'
 
     steps:
       - uses: actions/checkout@v4
@@ -127,6 +128,7 @@ jobs:
     timeout-minutes: 20
     env:
       DD_TEST_OPTIMIZATION_RUNNER_WORKER_ENV: DATABASE_URL_TEST=postgres://postgres:postgres@localhost:5432/Forem_test{{nodeIndex}};DATABASE_NAME_TEST=Forem_test{{nodeIndex}}
+      DD_TEST_OPTIMIZATION_RUNTIME_TAGS: '{"os.version":"6.12.80"}'
 
     services:
       postgres:


### PR DESCRIPTION
## Summary
- set DD_TEST_OPTIMIZATION_RUNNER_RUNTIME_TAGS for the ddtest plan job
- set DD_TEST_OPTIMIZATION_RUNTIME_TAGS for ddtest run jobs

## Validation plan
Use repeated branch commits to verify the plan job still fetches skippable tests while carrying os.version=6.12.80.

Confirmed overridden os.version on Ruby library side:
<img width="437" height="187" alt="image" src="https://github.com/user-attachments/assets/53cfb56e-166e-4dd2-8c1b-54cfcafb4562" />
